### PR TITLE
Partial order of square matrices

### DIFF
--- a/QuantumInfo/ForMathlib/Matrix.lean
+++ b/QuantumInfo/ForMathlib/Matrix.lean
@@ -381,6 +381,14 @@ theorem rinner_zero_mul : hA.rinner Matrix.isHermitian_zero = 0 := by
 theorem rinner_mul_zero : Matrix.isHermitian_zero.rinner hA = 0 := by
   simp [rinner]
 
+@[simp]
+theorem rinner_mul_one : hA.rinner Matrix.isHermitian_one = hA.rtrace := by
+  simp only [rinner, mul_one, rtrace]
+
+@[simp]
+theorem one_rinner_mul : Matrix.isHermitian_one.rinner hA = hA.rtrace := by
+  simp only [rinner, one_mul, rtrace]
+
 theorem rinner_smul_selfAdjoint {c : 𝕜} (hc : _root_.IsSelfAdjoint c) :
     (hA.smul_selfAdjoint hc).rinner hB = c * hA.rinner hB := by
   simp [rinner, RCLike.conj_eq_iff_re.mp hc, RCLike.conj_eq_iff_im.mp hc]
@@ -398,6 +406,16 @@ theorem rinner_smul_real {c : ℝ} :
 theorem smul_inner_real {c : ℝ} :
     hA.rinner (hB.smul_real c) = c * hA.rinner hB := by
   simp [rinner, RCLike.smul_re]
+
+@[simp]
+theorem rinner_add : hA.rinner (IsHermitian.add hB hC) = hA.rinner hB + hA.rinner hC := by
+  unfold rinner
+  rw [left_distrib, trace_add, map_add]
+
+@[simp]
+theorem rinner_sub : hA.rinner (IsHermitian.sub hB hC) = hA.rinner hB - hA.rinner hC := by
+  unfold rinner
+  rw [sub_eq_add_neg, left_distrib, trace_add, map_add, mul_neg, trace_neg, map_neg, ←sub_eq_add_neg]
 
 end IsHermitian
 namespace PosSemidef

--- a/QuantumInfo/ForMathlib/Matrix.lean
+++ b/QuantumInfo/ForMathlib/Matrix.lean
@@ -61,6 +61,15 @@ theorem smul_real (c : ℝ) : (c • A).IsHermitian := by
   ext
   simp only [smul_apply, smul_eq_mul, RCLike.real_smul_eq_coe_mul]
 
+def HermitianSubspace (n 𝕜 : Type*) [Fintype n] [RCLike 𝕜] : Subspace ℝ (Matrix n n 𝕜) where
+  carrier := { A : Matrix n n 𝕜 | A.IsHermitian }
+  add_mem' _ _ := by simp_all only [Set.mem_setOf_eq, IsHermitian.add]
+  zero_mem' := by simp only [Set.mem_setOf_eq, isHermitian_zero]
+  smul_mem' c A := by
+    simp only [Set.mem_setOf_eq]
+    intro hA
+    exact IsHermitian.smul_real hA c
+
 variable [Fintype n]
 
 include hA in

--- a/QuantumInfo/ForMathlib/Matrix.lean
+++ b/QuantumInfo/ForMathlib/Matrix.lean
@@ -299,6 +299,32 @@ theorem sqrt_nonneg_smul {c : 𝕜} (hA : (c^2 • A).PosSemidef) (hc : 0 < c) :
     apply posSemidef_sqrt
   rw [pow_two, Algebra.mul_smul_comm, Algebra.smul_mul_assoc, sqrt_mul_self, pow_two, smul_smul]
 
+include hA in
+theorem zero_dotProduct_zero_iff : (∀ x : m → 𝕜, 0 = star x ⬝ᵥ A.mulVec x) ↔ A = 0 := by
+  constructor
+  · intro h0
+    replace h0 := fun x ↦(PosSemidef.dotProduct_mulVec_zero_iff hA x).mp (h0 x).symm
+    ext i j
+    specialize h0 (Pi.single j 1)
+    rw [mulVec_single] at h0
+    replace h0 := congrFun h0 i
+    simp_all only [mul_one, Pi.zero_apply, zero_apply]
+  · intro h0
+    rw [h0]
+    simp only [zero_mulVec, dotProduct_zero, implies_true]
+
+theorem zero_posSemidef_neg_posSemidef_iff : A.PosSemidef ∧ (-A).PosSemidef ↔ A = 0 := by
+  constructor
+  · intro ⟨hA, hNegA⟩
+    have h0 : ∀ x : m → 𝕜, 0 = star x ⬝ᵥ A.mulVec x := fun x ↦ by
+      have hNegA' := hNegA.right x
+      rw [neg_mulVec, dotProduct_neg, le_neg, neg_zero] at hNegA'
+      exact le_antisymm (hA.right x) hNegA'
+    exact (zero_dotProduct_zero_iff hA).mp h0
+  · intro h0
+    rw [h0]
+    simp only [neg_zero, and_self, PosSemidef.zero]
+
 noncomputable section log
 
 /-- Matrix logarithm (base e) of a positive semidefinite matrix, as given by the elementwise


### PR DESCRIPTION
The main addition is the definition of a partial order for square matrices induced by their positive-semi-definiteness via `A ≤ B ↔ (B - A).PosSemidef`, along with useful properties.

Apart from being a central concept of the matrix algebra, another motivation for the definition of this partial order is its scattered use in the proof of the (generalized) quantum Stein's lemma. As a bonus, now `rinner_le_mul_trace` is proved.

I also defined `HermitianSubspace`, the real subspace of Hermitian matrices. It is not used, but seemed a low-hanging fruit from `smul_real`.